### PR TITLE
Use the Provisioner interface for session provisioning

### DIFF
--- a/route53.go
+++ b/route53.go
@@ -21,15 +21,17 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID: "dns.providers.route53",
 		New: func() caddy.Module {
-			p := &Provider{new(route53.Provider)}
-			// Initialize the AWS client session
-			err := p.NewSession()
-			if err != nil {
-				return nil
-			}
-			return p
+			return &Provider{new(route53.Provider)}
 		},
 	}
+}
+
+// Provision implements the Provisioner interface to initialize the AWS Client sessions
+func (p *Provider) Provision(ctx caddy.Context) error {
+	// Initialize the AWS client session
+	err := p.NewSession()
+
+	return err
 }
 
 // UnmarshalCaddyfile sets up the DNS provider from Caddyfile tokens. Syntax:

--- a/route53.go
+++ b/route53.go
@@ -29,9 +29,7 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 // Provision implements the Provisioner interface to initialize the AWS Client sessions
 func (p *Provider) Provision(ctx caddy.Context) error {
 	// Initialize the AWS client session
-	err := p.NewSession()
-
-	return err
+	return p.NewSession()
 }
 
 // UnmarshalCaddyfile sets up the DNS provider from Caddyfile tokens. Syntax:


### PR DESCRIPTION
Close #2 

Implements the `Provisioner` interface to execute the AWS Client session initialization.