### PR TITLE
fixed reference to old library in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/caddyserver/caddy/v2 v2.3.0
-	github.com/libdns/route53 v1.0.1
+	github.com/libdns/route53 v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821 h1:663opx/RKxiISi1oz
 github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
 github.com/libdns/libdns v0.1.0 h1:0ctCOrVJsVzj53mop1angHp/pE3hmAhP7KiHvR0HD04=
 github.com/libdns/libdns v0.1.0/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
-github.com/libdns/route53 v1.0.1 h1:xOJ//9+VUAbyc2N/k6piHyvQ8QVyxMfv9hjAKnucL6Y=
-github.com/libdns/route53 v1.0.1/go.mod h1:Mka4n7Qrt/zuQeQpiOzEzoywWvV2faNNKgYpXNxlAfo=
+github.com/libdns/route53 v1.1.0 h1:LnMHXiOwoDXKDR8w2LcjGttalZTJeuaXx4lMoLrBCAo=
+github.com/libdns/route53 v1.1.0/go.mod h1:Mka4n7Qrt/zuQeQpiOzEzoywWvV2faNNKgYpXNxlAfo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=


### PR DESCRIPTION
Fix to go.mod for bad reference (old version) to libdns