### PR TITLE
Add IAM policy example with more granular permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,47 @@ The following AWS IAM policy is a minimal working example to give `libdns` permi
 }
 ```
 
+Here is an example IAM policy that restricts `libdns` record management permissions to only the `_acme-challenge` `TXT` records in the specified hosted zone, which is sufficient for Caddy's automatic HTTPS functionality. (Note the placeholders for your hosted zone ID!):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "route53:ListHostedZonesByName",
+        "route53:ListHostedZones"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": "route53:ListResourceRecordSets",
+      "Effect": "Allow",
+      "Resource": "arn:aws:route53:::hostedzone/{{Replace with your hosted zone ID}}"
+    },
+    {
+      "Action": "route53:GetChange",
+      "Effect": "Allow",
+      "Resource": "arn:aws:route53:::change/*"
+    },
+    {
+      "Action": "route53:ChangeResourceRecordSets",
+      "Condition": {
+        "ForAllValues:StringEquals": {
+          "route53:ChangeResourceRecordSetsRecordTypes": "TXT"
+        },
+        "ForAllValues:StringLike": {
+          "route53:ChangeResourceRecordSetsNormalizedRecordNames": "_acme-challenge.*"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:route53:::hostedzone/{{Replace with your hosted zone ID}}"
+    }
+  ]
+}
+```
+
 ## Configuration
 
 To use this module for the ACME DNS challenge, configure the ACME issuer in your Caddyfile like so:


### PR DESCRIPTION
Hi and thanks for the project 💙 I deployed a server using this module recently and tinkered a bit to restrict the permissions for the Caddy machine so that it can only manage the required `_acme-challenge` records during certificate creation. In the spirit of lifting the security floor, I figured I'd send this as an example of a stricter policy. It's less "minimal" than the minimal example by line count, but more minimal in terms of the powers granted.

My policy of this form is working fine for my deployment, and I also tested that it rejects non-`TXT` or non-matching-subdomain changes via CLI.